### PR TITLE
Fixed FieldEngine limit of values

### DIFF
--- a/src/main/java/com/xored/javafx/packeteditor/scapy/PacketData.java
+++ b/src/main/java/com/xored/javafx/packeteditor/scapy/PacketData.java
@@ -60,7 +60,7 @@ public class PacketData {
                 }else if(prim.isString()){
                     return prim.getAsString();
                 }else if(prim.isNumber()){
-                    return prim.getAsInt();
+                    return prim.getAsLong();
                 }
             }
             return null;


### PR DESCRIPTION
- E.g. Ethernet address is 48 bits, but Java int is unable to fit it inside completely, but long is able.
So all values bigger than 4 bytes were limited