### PR TITLE
Add decompile vm raw support

### DIFF
--- a/src/main/java/com/xored/javafx/packeteditor/controllers/FieldEditorController.java
+++ b/src/main/java/com/xored/javafx/packeteditor/controllers/FieldEditorController.java
@@ -33,7 +33,10 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.input.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
+import javafx.scene.text.FontSmoothingType;
+import javafx.scene.text.Text;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import org.controlsfx.control.HiddenSidesPane;
@@ -325,6 +328,20 @@ public class FieldEditorController implements Initializable {
         }
     }
 
+    public void loadVmRaw(String vmRaw) {
+        if (packetController.isInitialized()) {
+            try {
+                String hlvm = packetController.decompileVmRaw(model.getPkt().getPacketBytes(), vmRaw);
+                model.loadHighLevelVmInstructions(hlvm);
+            } catch (Exception e) {
+                String content = "Unable to decomple raw VM instructions\n" +
+                        "make sure you use latest TRex server and Scapy server version: " +
+                        e.getMessage();
+                showWarning(content);
+            }
+        }
+    }
+
     public void writeToPcapFile(File file) {
         try {
             writeToPcapFile(file, model.getPkt(), false);
@@ -368,6 +385,20 @@ public class FieldEditorController implements Initializable {
         if (e != null ) {
             alert.getDialogPane().setExpandableContent(new ScrollPane(new TextArea(title + ": " + e.getMessage())));
         }
+        alert.showAndWait();
+    }
+
+    public void showWarning(String content) {
+        Alert alert = new Alert(Alert.AlertType.WARNING);
+        alert.setHeaderText(null);
+        Text text = new Text(content);
+        text.setWrappingWidth(350);
+        text.setFontSmoothingType(FontSmoothingType.LCD);
+
+        HBox container = new HBox();
+        container.getChildren().add(text);
+        alert.getDialogPane().setContent(container);
+
         alert.showAndWait();
     }
 

--- a/src/main/java/com/xored/javafx/packeteditor/controllers/FieldEditorController.java
+++ b/src/main/java/com/xored/javafx/packeteditor/controllers/FieldEditorController.java
@@ -335,7 +335,8 @@ public class FieldEditorController implements Initializable {
                 model.loadHighLevelVmInstructions(hlvm);
             } catch (Exception e) {
                 String content = "Unable to decomple raw VM instructions\n" +
-                        "make sure you use latest TRex server and Scapy server version: " +
+                        "make sure you use latest TRex server and Scapy server version\n" +
+                        "Error: " +
                         e.getMessage();
                 showWarning(content);
             }

--- a/src/main/java/com/xored/javafx/packeteditor/data/FEInstructionParameter2.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/FEInstructionParameter2.java
@@ -3,6 +3,7 @@ package com.xored.javafx.packeteditor.data;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.xored.javafx.packeteditor.metatdata.FEInstructionParameterMeta;
+import com.xored.javafx.packeteditor.scapy.FieldValue;
 
 import static com.xored.javafx.packeteditor.metatdata.FEInstructionParameterMeta.Type;
 
@@ -40,11 +41,25 @@ public class FEInstructionParameter2 {
         return meta.isRequired();
     }
 
-    public void setValue(String value) {
+    public void setRawValue(JsonElement value) {
+        this.value = value;
+    }
+
+    public void setHumanValue(String value) {
         this.value = new JsonPrimitive(value);
     }
 
     public boolean editable() {
         return meta.editable();
+    }
+
+    /** set raw eval python expression as a value */
+    public static JsonElement createExpressionValue(String expr) {
+        return FieldValue.create(FieldValue.ObjectType.EXPRESSION, "expr", expr);
+    }
+
+    /** set value from string */
+    public static JsonElement createHumanValue(String value) {
+        return new JsonPrimitive(value);
     }
 }

--- a/src/main/java/com/xored/javafx/packeteditor/data/HighLevelVmImporter.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/HighLevelVmImporter.java
@@ -1,0 +1,111 @@
+package com.xored.javafx.packeteditor.data;
+
+import com.google.gson.*;
+import com.google.inject.Inject;
+import com.xored.javafx.packeteditor.data.user.Document;
+import com.xored.javafx.packeteditor.metatdata.FeParameterMeta;
+import com.xored.javafx.packeteditor.metatdata.InstructionExpressionMeta;
+import com.xored.javafx.packeteditor.service.IMetadataService;
+import javafx.scene.control.Alert;
+import javafx.scene.layout.HBox;
+import javafx.scene.text.FontSmoothingType;
+import javafx.scene.text.Text;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class HighLevelVmImporter {
+    @Inject
+    IMetadataService metadataService;
+
+    private static final String INSTRUCTIONS = "instructions";
+    private static final String GLOBAL_PARAMETERS = "global_parameters";
+    private static final int WRAPPING_WIDTH = 350;
+
+    private Gson gson = new Gson();
+
+    public void importToUserModel(Document userModel, String hlvm) {
+        List<String> issues = new ArrayList<>();
+        JsonObject vm = gson.fromJson(hlvm, JsonElement.class).getAsJsonObject();
+
+        if (vm.has(INSTRUCTIONS)) {
+            parseInstructions(userModel, vm.get(INSTRUCTIONS).getAsJsonArray(), issues);
+        }
+
+        if (vm.has(GLOBAL_PARAMETERS)) {
+            parseGlobalParameters(userModel, vm.get(GLOBAL_PARAMETERS).getAsJsonObject(), issues);
+        }
+
+        if (!issues.isEmpty()) {
+            showAlert(issues);
+        }
+    }
+
+    private void parseInstructions(Document userModel, JsonArray instructions, List<String> issues) {
+        for (int i = 0; i < instructions.size(); i++) {
+            JsonObject instr = instructions.get(i).getAsJsonObject();
+            String id = instr.get("id").getAsString();
+
+            if (!metadataService.getFeInstructions().containsKey(id)) {
+                issues.add(MessageFormat.format("Command with id \"{0}\" doesn't exist",
+                        id));
+                continue;
+            }
+
+            InstructionExpressionMeta instructionMeta = metadataService.getFeInstructions().get(id);
+            JsonObject instr_params = instr.get("parameters").getAsJsonObject();
+            List<String> unvisited_params = instr_params.entrySet().stream().map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+
+            List<FEInstructionParameter2> parameters = instructionMeta.getParameterMetas().stream().map(meta -> {
+                    JsonPrimitive parameterValue = new JsonPrimitive(meta.getDefaultValue());
+                    if (instr_params.has(meta.getId())) {
+                        parameterValue = instr_params.get(meta.getId()).getAsJsonPrimitive();
+                        unvisited_params.remove(meta.getId());
+                    }
+                    return new FEInstructionParameter2(meta, parameterValue);
+                })
+                .collect(Collectors.toList());
+
+            unvisited_params.forEach((param) ->
+                issues.add(MessageFormat.format("Parameter \"{0}\", in instruction \"{1}\" was not found.",
+                        param,
+                        id))
+            );
+
+            InstructionExpression instruction = new InstructionExpression(instructionMeta, parameters);
+            userModel.addInstruction(instruction);
+        }
+    }
+
+    private void parseGlobalParameters(Document userModel, JsonObject global_parameters, List<String> issues) {
+        global_parameters.entrySet().forEach(entry -> {
+            if (metadataService.getFeParameters().containsKey(entry.getKey())) {
+                FeParameterMeta instructionMeta = metadataService.getFeParameters().get(entry.getKey());
+                userModel.createFePrarameter(instructionMeta, entry.getValue().getAsString());
+            } else {
+                issues.add(MessageFormat.format("Global parameter \"{0}\", was not found.",
+                        entry.getKey()));
+            }
+        });
+    }
+
+    private void showAlert(List<String> issues) {
+        Alert alert = new Alert(Alert.AlertType.WARNING);
+
+        String content = String.join("\n", issues);
+        Text text = new Text(content);
+        text.setWrappingWidth(WRAPPING_WIDTH);
+        text.setFontSmoothingType(FontSmoothingType.LCD);
+
+        HBox container = new HBox();
+        container.getChildren().add(text);
+        alert.getDialogPane().setContent(container);
+
+        alert.setHeaderText("There was errors while importing current stream");
+        alert.showAndWait();
+    }
+}

--- a/src/main/java/com/xored/javafx/packeteditor/data/InstructionExpression.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/InstructionExpression.java
@@ -1,5 +1,6 @@
 package com.xored.javafx.packeteditor.data;
 
+import com.google.gson.JsonElement;
 import com.google.gson.internal.LinkedTreeMap;
 import com.xored.javafx.packeteditor.data.user.DocumentFile.DocumentInstructionExpression;
 import com.xored.javafx.packeteditor.metatdata.InstructionExpressionMeta;
@@ -37,9 +38,9 @@ public class InstructionExpression {
     }
     
     public DocumentInstructionExpression toPOJO() {
-        Map<String, String> parametersPOJO =  new LinkedTreeMap<>();
+        Map<String, JsonElement> parametersPOJO =  new LinkedTreeMap<>();
         parameters.stream()
-                .forEach(parameter -> parametersPOJO.put(parameter.getId(), parameter.getValue().getAsString()));
+                .forEach(parameter -> parametersPOJO.put(parameter.getId(), parameter.getValue()));
         return new DocumentInstructionExpression(meta.getId(), parametersPOJO);        
     }
 }

--- a/src/main/java/com/xored/javafx/packeteditor/data/PacketEditorModel.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/PacketEditorModel.java
@@ -443,7 +443,7 @@ public class PacketEditorModel {
         });
     }
     
-    public void setVmInstructionParameter(FEInstructionParameter2 instructionParameter, String value) {
+    public void setVmInstructionParameter(FEInstructionParameter2 instructionParameter, JsonElement value) {
         beforeContentReplace();
         userModel.setFEInstructionParameter(instructionParameter, value);
         

--- a/src/main/java/com/xored/javafx/packeteditor/data/PacketEditorModel.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/PacketEditorModel.java
@@ -55,6 +55,9 @@ public class PacketEditorModel {
     @Inject
     IMetadataService metadataService;
 
+    @Inject
+    HighLevelVmImporter hlvmImporter;
+
     /** abstract user model. contains field values */
     Document userModel = new Document();
 
@@ -372,6 +375,12 @@ public class PacketEditorModel {
         this.packet = pkt;
         importUserModelFromScapy(packet);
         fireUpdateViewEvent();
+    }
+
+    public void loadHighLevelVmInstructions(String hlvm) {
+        beforeContentReplace();
+        hlvmImporter.importToUserModel(userModel, hlvm);
+        setPktAndReload(packetDataService.buildPacket(userModel.buildScapyModel(), userModel.getVmInstructionsModel()));
     }
 
     public void loadDocumentFromJSON(String jsonBase64) {

--- a/src/main/java/com/xored/javafx/packeteditor/data/user/Document.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/user/Document.java
@@ -74,8 +74,8 @@ public class Document {
         field.setValue(value);
     }
 
-    public void setFEInstructionParameter(FEInstructionParameter2 instructionParameter, String value) {
-        instructionParameter.setValue(value);
+    public void setFEInstructionParameter(FEInstructionParameter2 instructionParameter, JsonElement value) {
+        instructionParameter.setRawValue(value);
     }
     
     public UserProtocol getProtocolByPath(List<String> path) {

--- a/src/main/java/com/xored/javafx/packeteditor/data/user/DocumentFile.java
+++ b/src/main/java/com/xored/javafx/packeteditor/data/user/DocumentFile.java
@@ -44,9 +44,9 @@ public class DocumentFile {
 
     public static class DocumentInstructionExpression {
         public String id;
-        public Map<String, String> parameters = new LinkedTreeMap<>();
+        public Map<String, JsonElement> parameters = new LinkedTreeMap<>();
 
-        public DocumentInstructionExpression(String id, Map<String, String> parameters) {
+        public DocumentInstructionExpression(String id, Map<String, JsonElement> parameters) {
             this.id = id;
             this.parameters.putAll(parameters);
         }
@@ -94,7 +94,7 @@ public class DocumentFile {
             List<FEInstructionParameter2> instructionParameters = meta.getParameterMetas().stream()
                     .map(parameterMeta -> new FEInstructionParameter2(
                                                 parameterMeta,
-                                                new JsonPrimitive(instructionPOJO.parameters.get(parameterMeta.getId()))))
+                                                instructionPOJO.parameters.get(parameterMeta.getId())))
                     .collect(Collectors.toList());
             
             doc.addInstruction(new InstructionExpression(meta, instructionParameters));

--- a/src/main/java/com/xored/javafx/packeteditor/guice/GuiceModule.java
+++ b/src/main/java/com/xored/javafx/packeteditor/guice/GuiceModule.java
@@ -7,6 +7,7 @@ import com.google.inject.name.Names;
 import com.xored.javafx.packeteditor.TRexPacketCraftingTool;
 import com.xored.javafx.packeteditor.controllers.*;
 import com.xored.javafx.packeteditor.data.BinaryData;
+import com.xored.javafx.packeteditor.data.HighLevelVmImporter;
 import com.xored.javafx.packeteditor.data.IBinaryData;
 import com.xored.javafx.packeteditor.data.PacketEditorModel;
 import com.xored.javafx.packeteditor.guice.provider.FXMLLoaderProvider;
@@ -47,6 +48,7 @@ public class GuiceModule extends AbstractModule {
         bind(ScapyServerClient.class).in(Singleton.class);
         bind(PacketDataService.class).in(Singleton.class);
         bind(PacketEditorModel.class).in(Singleton.class);
+        bind(HighLevelVmImporter.class).in(Singleton.class);
         if (!embeddedMode) {
             bind(EventBus.class).in(Singleton.class);
         }

--- a/src/main/java/com/xored/javafx/packeteditor/metatdata/FEInstructionParameterMeta.java
+++ b/src/main/java/com/xored/javafx/packeteditor/metatdata/FEInstructionParameterMeta.java
@@ -2,9 +2,7 @@ package com.xored.javafx.packeteditor.metatdata;
 
 import java.util.Map;
 
-import static com.xored.javafx.packeteditor.metatdata.FEInstructionParameterMeta.Type.ENUM;
-import static com.xored.javafx.packeteditor.metatdata.FEInstructionParameterMeta.Type.NUMBER;
-import static com.xored.javafx.packeteditor.metatdata.FEInstructionParameterMeta.Type.STRING;
+import static com.xored.javafx.packeteditor.metatdata.FEInstructionParameterMeta.Type.*;
 
 public class FEInstructionParameterMeta {
 
@@ -47,6 +45,10 @@ public class FEInstructionParameterMeta {
     public boolean isEnum() {
         return ENUM.equals(getType());
     }
+
+    public boolean isExpression() {
+        return EXPRESSION.equals(getType());
+    }
     
     public Type getType() {
         switch (type) {
@@ -54,6 +56,8 @@ public class FEInstructionParameterMeta {
                 return ENUM;
             case "NUMBER":
                 return NUMBER;
+            case "EXPRESSION":
+                return EXPRESSION;
             case "STRING":
             default:
                 return STRING;
@@ -77,6 +81,6 @@ public class FEInstructionParameterMeta {
     }
 
     public enum Type {
-        STRING, ENUM, NUMBER
+        STRING, ENUM, NUMBER, EXPRESSION
     }
 }

--- a/src/main/java/com/xored/javafx/packeteditor/scapy/ScapyServerClient.java
+++ b/src/main/java/com/xored/javafx/packeteditor/scapy/ScapyServerClient.java
@@ -253,6 +253,14 @@ public class ScapyServerClient {
         return packetFromJson(first_packet);
     }
 
+    public String decompile_vm_raw(byte[] packet_binary, String vmRaw) {
+        JsonArray payload = new JsonArray();
+        payload.add(version_handler);
+        payload.add(base64Encoder.encodeToString(packet_binary));
+        payload.add(new Gson().fromJson(vmRaw, JsonElement.class));
+        return request("decompile_vm_raw", payload).toString();
+    }
+
     /** write single pcap packet to a file, returns result binary pcap file content */
     public byte[] write_pcap_packet(byte[] packet_binary) {
         JsonArray packets = new JsonArray();

--- a/src/main/java/com/xored/javafx/packeteditor/service/PacketDataService.java
+++ b/src/main/java/com/xored/javafx/packeteditor/service/PacketDataService.java
@@ -100,6 +100,10 @@ public class PacketDataService {
         return scapy.read_pcap_packet(binaryData);
     }
 
+    public String decompileVmRaw(byte[] binaryData, String vmRaw) {
+        return scapy.decompile_vm_raw(binaryData, vmRaw);
+    }
+
     public void closeConnection() {
         scapy.closeConnection();
     }


### PR DESCRIPTION
- Added support of decompilation vm raw instructions (at the current moment, trex-core doesn't support this)
- Changed Document to store FieldEngine instructions in JsonElements (not in Strings, or JsonPrimitives)