### PR TITLE
Fixed payload doesn't imported from native profile

### DIFF
--- a/src/main/java/com/xored/javafx/packeteditor/controls/ProtocolField.java
+++ b/src/main/java/com/xored/javafx/packeteditor/controls/ProtocolField.java
@@ -315,6 +315,7 @@ public class ProtocolField extends EditableField {
         }
         else {
             pe.setText(combinedField.getScapyDisplayValue());
+            commitChanges(pe);
         }
 
         pe.setOnActionSave((event) -> {


### PR DESCRIPTION
After payload imported, it was overwritten, because user model has not payload, and on next rebuild_packet routine, it resets.